### PR TITLE
Bugfix for the hand-crafted feature embeddings

### DIFF
--- a/resource/create_X2id.py
+++ b/resource/create_X2id.py
@@ -26,14 +26,14 @@ def main():
                 else:
                     feature2freq[feature] += 1
 
-    def _local(file_path, X2freq):
+    def _local(file_path, X2freq, start_idx=0):
         with open(file_path,"w") as f:
-            for i,(X,freq) in enumerate(sorted(X2freq.items(),key = lambda t: -t[1])):
+            for i,(X,freq) in enumerate(sorted(X2freq.items(),key = lambda t: -t[1]), start_idx):
                 f.write(str(i)+"\t"+X+"\t"+str(freq)+"\n")
 
     _local(sys.argv[2],word2freq)
-    _local(sys.argv[3],feature2freq)
+    _local(sys.argv[3],feature2freq, start_idx=1)
     _local(sys.argv[4],label2freq)
-    
+
 if(__name__=='__main__'):
     main()

--- a/src/model/nn_model.py
+++ b/src/model/nn_model.py
@@ -135,7 +135,7 @@ class Model:
         feed = {self.mention_representation: mention_representation_data,
                 self.target: target_data,
                 self.keep_prob: [0.5]}
-        if self.feature == True: # and feature_data != None:
+        if self.feature == True and feature_data is not None:
             feed[self.features] = feature_data
         for i in range(self.context_length*2+1):
             feed[self.context[i]] = context_data[:,i,:]
@@ -145,7 +145,7 @@ class Model:
         feed = {self.mention_representation: mention_representation_data,
                 self.target: target_data,
                 self.keep_prob: [1.0]}
-        if self.feature == True: # and feature_data != None:
+        if self.feature == True and feature_data is not None:
             feed[self.features] = feature_data
         for i in range(self.context_length*2+1):
             feed[self.context[i]] = context_data[:,i,:]
@@ -154,7 +154,7 @@ class Model:
     def predict(self, context_data, mention_representation_data, feature_data=None):
         feed = {self.mention_representation: mention_representation_data,
                 self.keep_prob: [1.0]}
-        if self.feature == True: # and feature_data != None:
+        if self.feature == True and feature_data is not None:
             feed[self.features] = feature_data
         for i in range(self.context_length*2+1):
             feed[self.context[i]] = context_data[:,i,:]

--- a/src/model/nn_model.py
+++ b/src/model/nn_model.py
@@ -6,15 +6,18 @@ sys.path.append('../../')
 sys.path.append('../')
 from create_prior_knowledge import create_prior
 
-def weight_variable(shape):
-    initial = tf.random_uniform(shape,minval=-0.01, maxval=0.01)
-    return tf.Variable(initial)
+def weight_variable(name, shape, pad=True):
+    initial = np.random.uniform(-0.01, 0.01, size=shape)
+    if pad == True:
+        initial[0] = np.zeros(shape[1])
+    initial = tf.constant_initializer(initial)
+    return tf.get_variable(name=name, shape=shape, initializer=initial)
 
 def attentive_sum(inputs,input_dim, hidden_dim):
     with tf.variable_scope("attention"):
         seq_length = len(inputs)
-        W =  weight_variable((input_dim,hidden_dim))
-        U =  weight_variable((hidden_dim,1))
+        W =  weight_variable('att_W', (input_dim,hidden_dim))
+        U =  weight_variable('att_U', (hidden_dim,1))
         tf.get_variable_scope().reuse_variables()
         temp1 = [tf.nn.tanh(tf.matmul(inputs[i],W)) for i in range(seq_length)]
         temp2 = [tf.matmul(temp1[i],U) for i in range(seq_length)]
@@ -27,7 +30,7 @@ def attentive_sum(inputs,input_dim, hidden_dim):
 
 class Model:
     def __init__(self,type = "figer", encoder = "averaging", hier = False, feature = False):
-        
+
         # Argument Checking
         assert(encoder in ["averaging", "lstm", "attentive"])
         assert(type in ["figer", "gillick"])
@@ -35,8 +38,8 @@ class Model:
         self.encoder = encoder
         self.hier = hier
         self.feature = feature
-            
-        # Hyperparameters   
+
+        # Hyperparameters
         self.context_length = 10
         self.emb_dim = 300
         self.target_dim = 113 if type == "figer" else 89
@@ -93,13 +96,13 @@ class Model:
             with tf.variable_scope("rnn_right") as scope:
                 self.right_birnn,_,_ = tf.nn.bidirectional_rnn(self.right_lstm_F,self.right_lstm_B,list(reversed(self.right_context)),dtype=tf.float32)
             self.context_representation, self.attentions = attentive_sum(self.left_birnn + self.right_birnn, input_dim = self.lstm_dim * 2, hidden_dim = self.att_dim)
-                                                    
+
 
         # Logistic Regression
         if feature:
             self.features = tf.placeholder(tf.int32,[None,self.feature_input_dim])
-            self.feature_embeddings = weight_variable((self.feature_size, self.feature_dim))
-            self.feature_representation = tf.nn.dropout(tf.reduce_sum(tf.nn.embedding_lookup(self.feature_embeddings,self.features),1),self.keep_prob) 
+            self.feature_embeddings = weight_variable('feat_embds', (self.feature_size, self.feature_dim), True)
+            self.feature_representation = tf.nn.dropout(tf.reduce_sum(tf.nn.embedding_lookup(self.feature_embeddings,self.features),1),self.keep_prob)
             self.representation = tf.concat(1, [self.mention_representation_dropout, self.context_representation, self.feature_representation])
         else:
             self.representation = tf.concat(1, [self.mention_representation_dropout, self.context_representation])
@@ -109,13 +112,13 @@ class Model:
             S = create_prior("./resource/"+_d+"/label2id_"+type+".txt")
             assert(S.shape == (self.target_dim, self.target_dim))
             self.S = tf.constant(S,dtype=tf.float32)
-            self.V = weight_variable((self.target_dim,self.rep_dim))
+            self.V = weight_variable('hier_V', (self.target_dim,self.rep_dim))
             self.W = tf.transpose(tf.matmul(self.S,self.V))
             self.logit = tf.matmul(self.representation, self.W)
         else:
-            self.W = weight_variable((self.rep_dim,self.target_dim))
+            self.W = weight_variable('hier_W', (self.rep_dim,self.target_dim))
             self.logit = tf.matmul(self.representation, self.W)
-    
+
         self.distribution = tf.nn.sigmoid(self.logit)
 
         # Loss Function
@@ -132,7 +135,7 @@ class Model:
         feed = {self.mention_representation: mention_representation_data,
                 self.target: target_data,
                 self.keep_prob: [0.5]}
-        if self.feature == True and feature_data != None:
+        if self.feature == True: # and feature_data != None:
             feed[self.features] = feature_data
         for i in range(self.context_length*2+1):
             feed[self.context[i]] = context_data[:,i,:]
@@ -142,7 +145,7 @@ class Model:
         feed = {self.mention_representation: mention_representation_data,
                 self.target: target_data,
                 self.keep_prob: [1.0]}
-        if self.feature == True and feature_data != None:
+        if self.feature == True: # and feature_data != None:
             feed[self.features] = feature_data
         for i in range(self.context_length*2+1):
             feed[self.context[i]] = context_data[:,i,:]
@@ -151,7 +154,7 @@ class Model:
     def predict(self, context_data, mention_representation_data, feature_data=None):
         feed = {self.mention_representation: mention_representation_data,
                 self.keep_prob: [1.0]}
-        if self.feature == True and feature_data != None:
+        if self.feature == True: # and feature_data != None:
             feed[self.features] = feature_data
         for i in range(self.context_length*2+1):
             feed[self.context[i]] = context_data[:,i,:]
@@ -165,6 +168,6 @@ class Model:
 
     def save_label_embeddings(self):
         pass
-        
 
-    
+
+


### PR DESCRIPTION
Hi Sonse! I found a bug in your code which could be critical:  [Here](https://github.com/shimaokasonse/NFGEC/blob/master/src/batcher.py#L28) when you create a batch, the features are put in a fixed length (70) of vector. However, the length of features is not always 70. When it is shorter than 70, you use "**0**" as padding elements (see [Here](https://github.com/shimaokasonse/NFGEC/blob/master/create_dataset.py#L12)), but "**0**" is already used as the id of the most frequent feature (see [here](https://github.com/shimaokasonse/NFGEC/blob/master/create_dicts.py#L8)). This make these padding elements wrongly contribute to the feature representation (see [here](https://github.com/shimaokasonse/NFGEC/blob/master/src/model/nn_model.py#L102)).

I've fixed this bug in the pull request. Let me know if you have any question.

Best,
Sheng